### PR TITLE
Verify config.json and add all the missing info

### DIFF
--- a/conf/resinhup.conf
+++ b/conf/resinhup.conf
@@ -46,7 +46,7 @@ remote: https://s3.amazonaws.com/resin-production-hup/
 workspace: /tmp/resinhup
 update_file_fingerprints: ./resin-boot ./resin-root
 
-[production]
+[staging]
 apiEndpoint: https://api.resinstaging.io
 listenPort: 48484
 mixpanelToken: cb974f32bab01ecc1171937026774b18
@@ -56,7 +56,7 @@ registryEndpoint: registry.resinstaging.io
 vpnEndpoint: vpn.resinstaging.io
 vpnPort: 443
 
-[staging]
+[production]
 apiEndpoint: https://api.resin.io
 listenPort: 48484
 mixpanelToken: 99eec53325d4f45dd0633abd719e3ff1

--- a/conf/resinhup.conf
+++ b/conf/resinhup.conf
@@ -45,3 +45,23 @@ to_keep_files:
 remote: https://s3.amazonaws.com/resin-production-hup/
 workspace: /tmp/resinhup
 update_file_fingerprints: ./resin-boot ./resin-root
+
+[production]
+apiEndpoint: https://api.resinstaging.io
+listenPort: 48484
+mixpanelToken: cb974f32bab01ecc1171937026774b18
+pubnubPublishKey: pub-c-6cbce8db-bfd1-4fdf-a8c8-53671ae2b226
+pubnubSubscribeKey: sub-c-bbc12eba-ce4a-11e3-9782-02ee2ddab7fe
+registryEndpoint: registry.resinstaging.io
+vpnEndpoint: vpn.resinstaging.io
+vpnPort: 443
+
+[staging]
+apiEndpoint: https://api.resin.io
+listenPort: 48484
+mixpanelToken: 99eec53325d4f45dd0633abd719e3ff1
+pubnubPublishKey: pub-c-6cbce8db-bfd1-4fdf-a8c8-53671ae2b226
+pubnubSubscribeKey: sub-c-bbc12eba-ce4a-11e3-9782-02ee2ddab7fe
+registryEndpoint: registry.resin.io
+vpnEndpoint: vpn.resin.io
+vpnPort: 443

--- a/modules/updater.py
+++ b/modules/updater.py
@@ -302,6 +302,25 @@ class Updater:
 
         return True
 
+    def verifyConfigJson(self):
+        log.info("verifyConfigJson: Verifying and fixing config.json")
+        ctype = getConfigurationItem(self.conf, 'config.json', 'type')
+        if not ctype:
+            log.error("Don't know if staging/production.")
+            return False
+        try:
+            options = getSectionOptions(self.conf, ctype)
+            configjsonpath = getConfJsonPath(self.conf)
+            for option in options:
+                if not jsonAttributeExists(configjsonpath, option):
+                    value = getConfigurationItem(self.conf, ctype, option)
+                    log.debug("verifyConfigJson: Fixing config.json: " + option + "=" + value + ".")
+                    jsonSetAttribute(configjsonpath, option, value)
+        except:
+            log.error("verifyConfigJson: Error while verifying config.json.")
+            return False
+        return True
+
     def upgradeSystem(self):
         log.info("Started to upgrade system.")
         if not self.updateRootfs():
@@ -312,6 +331,9 @@ class Updater:
             return False
         if not self.fixFsLabels():
             log.error("Could not fix/setup fs labels.")
+            return False
+        if not self.verifyConfigJson():
+            log.error("Could not verify config.json.")
             return False
         # Configure bootloader to use the updated rootfs
         if runningDevice(self.conf) == 'raspberry-pi' or runningDevice(self.conf) == 'raspberry-pi2':

--- a/modules/util.py
+++ b/modules/util.py
@@ -415,6 +415,7 @@ def jsonSetAttribute(json, attribute, value, onlyIfNotDefined=False):
     try:
         with open(json+'.hup.tmp', 'w') as fd:
             configjson = json.dump(configjson, fd)
+            os.fsync(fd)
     except:
         log.error("jsonSetAttribute: Can't write or encode to " + json + ".")
         return False

--- a/resinhup.py
+++ b/resinhup.py
@@ -41,6 +41,8 @@ def main():
                       help = "Configuration file to be used. Default: " + default_resinhup_conf_file)
     parser.add_argument('-f', '--force-fingerprint', action = 'store_true', dest = 'force_fingerprint', default = False,
                       help = "Avoid fingerprint check and force update. Do it on your own risk.")
+    parser.add_argument('-s', '--staging', action = 'store_true', dest = 'staging', default = False,
+                      help = "Validate and configure config.json against staging values.")
     args = parser.parse_args()
 
     # Logger
@@ -98,6 +100,14 @@ def main():
             log.info("Fingerprint validation succeeded.")
     else:
         log.debug("Fingerprint scan avoided due to flag or env.")
+
+    # Staging / production
+    if args.staging:
+        if not setConfigurationItem(args.conf, "config.json", "type", "staging"):
+            return False
+    else
+        if not setConfigurationItem(args.conf, "config.json", "type", "production"):
+            return False
 
     f = tarFetcher(args.conf)
     if not f.unpack(downloadFirst=True):


### PR DESCRIPTION
Verify config.json and add all the missing info there based on running flag

Based on --staging argument (default to production when not present),
config.json will be check for all the required attributes and fix accordingly.

Signed-off-by: Andrei Gherzan <andrei@resin.io>

CC @petrosagg @telphan @floion

PR for #3
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-os/resinhup/4)
<!-- Reviewable:end -->
