### PR TITLE
resinhup.conf: Keep /etc/supervisor.conf over updates

### DIFF
--- a/conf/resinhup.conf
+++ b/conf/resinhup.conf
@@ -38,6 +38,7 @@ possible_locations: /mnt/conf /mnt/data-disk
 to_keep_files:
     /etc/dropbear/dropbear_rsa_host_key
     /etc/machine-id
+    /etc/supervisor.conf
     /var/lib/systemd/random-seed
     /var/lib/urandom/random-seed:/var/lib/systemd/random-seed
     /var/lib/dropbear/authorized_keys


### PR DESCRIPTION
This file might have been already change by supervisor updates.

Signed-off-by: Andrei Gherzan <andrei@resin.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-os/resinhup/13)
<!-- Reviewable:end -->
