### PR TITLE
updater: remove outdated code and misleading error message

### DIFF
--- a/modules/updater.py
+++ b/modules/updater.py
@@ -307,13 +307,7 @@ class Updater:
 
         # resin-data
         if not getDevice("resin-data"):
-            log.error("Can't label btrfs partition. You need to do it manually on host OS with: btrfs filesystem label <X> resin-data .")
             return False
-            #btrfspartition = getBTRFSPartition(self.conf)
-            #if not btrfspartition:
-            #    return False
-            #if not setBTRFSDeviceLabel(btrfspartition, "resin-data"):
-            #    return False
 
         return True
 


### PR DESCRIPTION
btrfs is no longer used for resin-data. This error message is misleading.

Also remove some commented out code.