### PR TITLE
Fixes

### DIFF
--- a/conf/resinhup.conf
+++ b/conf/resinhup.conf
@@ -25,6 +25,8 @@ root_whitelist:
     etc/wpa_supplicant/entropy.bin
     .rce/key.json
     usr/bin/run-resinhup.sh
+    usr/bin/update-resin-supervisor
+    etc/supervisor.conf
 boot_defaultFingerPrintFile: resin-boot.fingerprint
 boot_whitelist:
     cmdline.txt

--- a/scripts/docker-build-and-push.sh
+++ b/scripts/docker-build-and-push.sh
@@ -5,7 +5,7 @@ set -e
 GREEN='\033[0;32m'
 NC='\033[0m'
 TAG=latest
-REGISTRY=registry.resinstaging.io/resinhup
+REGISTRY="registry.resinstaging.io/resin/resinhup resin/resinhup-test"
 
 # Help function
 function help {
@@ -92,8 +92,9 @@ for dockerfile in $DOCKERFILES; do
         exit 1
     fi
     printf "${GREEN}Running build for $device using $dockerfile ...${NC}\n"
-    docker build -t resinhup-$device:$TAG -f ../$dockerfile $SCRIPTPATH/..
-    printf "${GREEN}Tag and push for $device ...${NC}\n"
-    docker tag -f resinhup-$device:$TAG $REGISTRY/resinhup-$device:$TAG
-    docker push $REGISTRY/resinhup-$device:$TAG
+    for registry in $REGISTRY; do
+        printf "${GREEN}Tag and push for $device ...${NC}\n"
+        docker build -t $registry:$TAG-$device -f ../$dockerfile $SCRIPTPATH/..
+        docker push $registry:$TAG-$device
+    done
 done


### PR DESCRIPTION
supervisor.conf - can be modified by update-resin-supervisor
update-resin-supervisor - is scp'd via ssh/vpn while running resinhup ssh wrapper

Signed-off-by: Andrei Gherzan <andrei@resin.io>

Fixes https://github.com/resin-os/resinhup/issues/45