### PR TITLE
Whitelist etc/openvpn/resin.conf fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+ - Whitelist etc/openvpn/resin.conf to allow resinhup on staging [Will]
+
 ## v1.1.1 - 2017-01-23
 
  - Implement ability to downgrade through argument and environment variable [Andrei]

--- a/conf/resinhup.conf
+++ b/conf/resinhup.conf
@@ -27,6 +27,7 @@ root_whitelist:
     usr/bin/run-resinhup.sh
     usr/bin/update-resin-supervisor
     etc/supervisor.conf
+    etc/openvpn/resin.conf
 boot_defaultFingerPrintFile: resin-boot.fingerprint
 boot_whitelist:
     cmdline.txt


### PR DESCRIPTION
This should allow us to do resinhup upgrades on staging devices.