### PR TITLE
legacy-config: fix bug when migrating config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+ - legacy-config: fix copy bug when migrating config.json
+
 ## v1.1.3 - 2017-05-25
 
  - Whitelist etc/hostname [Gergely]

--- a/modules/updater.py
+++ b/modules/updater.py
@@ -252,7 +252,7 @@ class Updater:
                 jsonSetAttribute(tmpconfig, 'vpnEndpoint', vpnEndpoint, onlyIfNotDefined=True)
 
                 # Copy the temp config.json to resin-boot
-                if not safeCopy(tmpconfig, bootmountpoint):
+                if not safeCopy(tmpconfig, os.path.join(bootmountpoint, 'config.json')):
                     return False
                 os.remove(tmpconfig)
             elif os.path.isfile(os.path.join(root_mount, "mnt/conf/config.json")):


### PR DESCRIPTION
Trying to copy with wrong syntax (to a directory, instead of a file),
which breaks update process.

Commit-type: patch
Signed-off-by: Gergely Imreh <imrehg@gmail.com>