### PR TITLE
further improvements to the 2.x->2.x updater

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -134,7 +134,7 @@ function upgradeSupervisor() {
 
     if CURRENT_SUPERVISOR_VERSION=$(curl -s "${API_ENDPOINT}/v2/device(${DEVICEID})?\$select=supervisor_version&apikey=${APIKEY}" | jq -r '.d[0].supervisor_version'); then
         if [ -z "$CURRENT_SUPERVISOR_VERSION" ]; then
-            log WARN "Could not get current supervisor version from the API, skipping update..."
+            log ERROR "Could not get current supervisor version from the API..."
         else
             if version_gt "$target_supervisor_version" "$CURRENT_SUPERVISOR_VERSION" ; then
                 log "Supervisor update: will be upgrading from v${CURRENT_SUPERVISOR_VERSION} to ${target_supervisor_version}"
@@ -150,7 +150,7 @@ function upgradeSupervisor() {
                     stop_services
                     remove_containers
                 else
-                    log WARN "Couldn't extract supervisor vars..."
+                    log ERROR "Couldn't extract supervisor vars..."
                 fi
             else
                 log "Supervisor update: no update needed."

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -88,11 +88,20 @@ function stop_services() {
     docker stop resin_supervisor > /dev/null 2>&1 || true
 }
 
+function remove_containers() {
+    stop_services
+    log "Stopping all containers.."
+    docker stop $(docker ps -a -q) > /dev/null 2>&1 || true
+    log "Removing all containers..."
+    docker rm $(docker ps -a -q) > /dev/null 2>&1 || true
+}
+
 function upgradeToReleaseSupervisor() {
     # Fetch what supervisor version the target hostOS was originally released with
     # and if it's newer than the supervisor running on the device, then fetch the
     # information that is required for supervisor update, then do the update with
     # the tools shipped with the hostOS.
+    log "Supervisor update start..."
     if [ "$STAGING" == "yes" ]; then
         DEFAULT_SUPERVISOR_VERSION_URL_BASE="https://s3.amazonaws.com/resin-staging-img/"
     else
@@ -124,7 +133,7 @@ function upgradeToReleaseSupervisor() {
                     log "Running supervisor updater..."
                     progress 90 "ResinOS: running supervisor update..."
                     update-resin-supervisor
-                    stop_services
+                    remove_containers
                 else
                     log WARN "Couldn't extract supervisor vars..."
                 fi

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -97,8 +97,10 @@ function stop_services() {
 function remove_containers() {
     stop_services
     log "Stopping all containers.."
+    # shellcheck disable=SC2046
     docker stop $(docker ps -a -q) > /dev/null 2>&1 || true
     log "Removing all containers..."
+    # shellcheck disable=SC2046
     docker rm $(docker ps -a -q) > /dev/null 2>&1 || true
 }
 

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -292,8 +292,8 @@ fi
 
 # fix resin-device-progress, between version 2.0.6 and 2.3.0
 # the script does not work using deviceApiKey
-if version_gt "$VERSION" "2.0.6" &&
-    version_gt "2.3.0" "$VERSION"; then
+if version_gt "$VERSION_ID" "2.0.6" &&
+    version_gt "2.3.0" "$VERSION_ID"; then
         log "Fixing resin-device-progress is required..."
         tools_path=/tmp/upgrade_tools_extra
         mkdir -p $tools_path

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -161,6 +161,13 @@ function upgradeSupervisor() {
     fi
 }
 
+function error_handler() {
+    # If script fails (e.g. docker pull fails), restart the stopped services like the supervisor
+    systemctl start resin-supervisor
+    systemctl start update-resin-supervisor.timer
+    exit 1
+}
+
 ###
 # Script start
 ###
@@ -362,6 +369,8 @@ fi
 stop_services
 
 image=resin/resinos:${target_version}-${SLUG}
+
+trap 'error_handler' ERR
 
 log "Getting new OS image..."
 progress 50 "ResinOS: downloading update package..."

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -290,6 +290,21 @@ if ! version_gt "$VERSION" "$preferred_hostos_version" &&
     esac
 fi
 
+# fix resin-device-progress, between version 2.0.6 and 2.3.0
+# the script does not work using deviceApiKey
+if version_gt "$VERSION" "2.0.6" &&
+    version_gt "2.3.0" "$VERSION"; then
+        log "Fixing resin-device-progress is required..."
+        tools_path=/tmp/upgrade_tools_extra
+        mkdir -p $tools_path
+        export PATH=$tools_path:$PATH
+        download_url=https://raw.githubusercontent.com/resin-os/meta-resin/v2.3.0/meta-resin-common/recipes-support/resin-device-progress/resin-device-progress/resin-device-progress
+        curl -f -s -L -o $tools_path/resin-device-progress $download_url || log WARNING "Couldn't download tool from $download_url, progress bar won't work, but not aborting..."
+        chmod 755 $tools_path/resin-device-progress
+else
+    log "No resin-device-progress fix is required..."
+fi
+
 log "Loading info from config.json"
 if [ -f /mnt/boot/config.json ]; then
     CONFIGJSON=/mnt/boot/config.json

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -95,7 +95,6 @@ function stop_services() {
 }
 
 function remove_containers() {
-    stop_services
     log "Stopping all containers.."
     # shellcheck disable=SC2046
     docker stop $(docker ps -a -q) > /dev/null 2>&1 || true
@@ -148,6 +147,7 @@ function upgradeSupervisor() {
                     log "Running supervisor updater..."
                     progress 90 "ResinOS: running supervisor update..."
                     update-resin-supervisor
+                    stop_services
                     remove_containers
                 else
                     log WARN "Couldn't extract supervisor vars..."

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -102,7 +102,7 @@ function remove_containers() {
     docker rm $(docker ps -a -q) > /dev/null 2>&1 || true
 }
 
-function upgradeToReleaseSupervisor() {
+function upgradeSupervisor() {
     # Fetch what supervisor version the target hostOS was originally released with
     # and if it's newer than the supervisor running on the device, then fetch the
     # information that is required for supervisor update, then do the update with
@@ -423,7 +423,7 @@ case $SLUG in
 esac
 
 # Updating supervisor
-upgradeToReleaseSupervisor
+upgradeSupervisor
 
 # Reboot into new OS
 sync

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -274,7 +274,7 @@ if ! version_gt "$VERSION" "$preferred_hostos_version" &&
             done
             ;;
         x86)
-            download_uri=https://github.com/imrehg/resinhup/raw/twototwo-fixes/upgrade-binaries/$binary_type
+            download_uri=https://github.com/resin-os/resinhup/raw/master/upgrade-binaries/$binary_type
             for binary in $tools_binaries; do
                 log "Installing $binary..."
                 curl -f -s -L -o $tools_path/$binary $download_uri/$binary || log ERROR "Couldn't download tool from $download_uri/$binary, aborting."

--- a/upgrade-ssh-2.x.sh
+++ b/upgrade-ssh-2.x.sh
@@ -41,6 +41,10 @@ Options:
         See ${main_script_name} help for more details.
         This is a mandatory argument.
 
+  --supervisor-version <SUPERVISOR_VERSION>
+        Run ${main_script_name} with --supervisor-version <SUPERVISOR_VERSION>, use e.g. 6.2.5
+        See ${main_script_name} help for more details.
+
   --no-reboot
         Run ${main_script_name} with --no-reboot . See ${main_script_name} help for more details.
 
@@ -197,6 +201,14 @@ while [[ $# -gt 0 ]]; do
             fi
             HOSTOS_VERSION=$2
             RESINHUP_ARGS+=( "--hostos-version $HOSTOS_VERSION" )
+            shift
+            ;;
+        --supervisor-version)
+            if [ -z "$2" ]; then
+                log ERROR "\"$1\" argument needs a value."
+            fi
+            SUPERVISOR_VERSION=$2
+            RESINHUP_ARGS+=( "--supervisor-version $SUPERVISOR_VERSION" )
             shift
             ;;
         --no-reboot)


### PR DESCRIPTION
This includes:

* supervisor update automatically to the target resinOS version's shipped supervisor or as defined on the command line with `--supervisor-versions`
* add `resin-device-progress` on devices that shipped with broken version (above 2.6.0 and below 2.3.0, those two versions are good)
* update x86 tools download path
* restart supervisor if the script exits with an error
* other small fixes for shellcheck and scripting

Can squash it in the end, that would be likely better? Any feedback is appreciated. Done more than 100 updates with this setup, seems like getting better and more stable, when I don't do silly things...