### PR TITLE
upgrade-2.x: changes in preparation to self-service hup

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -224,7 +224,7 @@ function remove_sample_wifi {
     # connection settings, as they are well known and thus insecure
     local filename=$1
     if [ -f "${filename}" ] && grep -Fxq "ssid=My_Wifi_Ssid" "${filename}" && grep -Fxq "psk=super_secret_wifi_password" "${filename}" ; then
-        if nmcli | grep "resin-sample"; then
+        if nmcli c  show --active | grep "resin-sample" ; then
             # If a connection with that name is in use, do not actually remove the settings
             log WARN "resin-sample configuration found at ${filename} but it might be connected, not removing..."
         else

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -420,13 +420,9 @@ if [ -f /mnt/boot/config.json ]; then
 else
     log ERROR "Don't know where config.json is."
 fi
-APIKEY=$(jq -r '.deviceApiKey' $CONFIGJSON)
-if [ "$APIKEY" == 'null' ]; then
-    log WARN "Using apiKey as device does not have deviceApiKey yet..."
-    APIKEY=$(jq -r '.apiKey' $CONFIGJSON)
-fi
-DEVICEID=$(jq -r '.deviceId' $CONFIGJSON)
-API_ENDPOINT=$(jq -r '.apiEndpoint' $CONFIGJSON)
+# If the user api key exists we use it instead of the deviceApiKey as it means we haven't done the key exchange yet
+# shellcheck disable=SC2046
+read -r APIKEY DEVICEID API_ENDPOINT <<<$(jq -r '.apiKey // .deviceApiKey,.deviceId,.apiEndpoint' $CONFIGJSON)
 
 # Find which partition is / and which we should write the update to
 root_part=$(findmnt -n --raw --evaluate --output=source /)

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -2,6 +2,8 @@
 
 NOREBOOT=no
 STAGING=no
+LOG=yes
+SCRIPTNAME=upgrade-2.x.sh
 
 set -o errexit
 set -o pipefail
@@ -44,6 +46,9 @@ Options:
         Omit the 'v' in front of the version. e.g.: 6.2.5 and not v6.2.5
         If not defined, then the update will try to run for the HOSTOS_VERSION's
         original supervisor release.
+
+    -n, --nolog
+        By default tool logs to stdout and file. This flag deactivates log to file.
 
   --no-reboot
         Do not reboot if update is successful. This is useful when debugging.
@@ -195,6 +200,9 @@ while [[ $# -gt 0 ]]; do
             target_supervisor_version=$2
             shift
             ;;
+        -n|--nolog)
+            LOG=no
+            ;;
         --no-reboot)
             NOREBOOT="yes"
             ;;
@@ -214,6 +222,14 @@ fi
 
 # Log timer
 starttime=$(date +%s)
+
+# LOGFILE init and header
+if [ "$LOG" == "yes" ]; then
+    LOGFILE="/mnt/data/resinhup/$SCRIPTNAME.$(date +"%Y%m%d_%H%M%S").log"
+    mkdir -p "$(dirname "$LOGFILE")"
+    echo "================$SCRIPTNAME HEADER START====================" > "$LOGFILE"
+    date >> "$LOGFILE"
+fi
 
 progress 25 "ResinOS: preparing update.."
 

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -349,16 +349,21 @@ API_ENDPOINT=$(jq -r '.apiEndpoint' $CONFIGJSON)
 
 # Find which partition is / and which we should write the update to
 root_part=$(findmnt -n --raw --evaluate --output=source /)
+log "Found root at ${root_part}..."
 case $root_part in
-    *p2)
-        root_dev=${root_part%p2}
-        update_part=${root_dev}p3
+    *2)
+        # on 2.x the following device types have these kinds of results for $root_part
+        # raspberrypi: /dev/mmcblk0p2
+        # beaglebone: /dev/disk/by-partuuid/93956da0-02
+        # NUC: /dev/sda2
+        root_dev=${root_part%2}
+        update_part=${root_dev}3
         update_part_no=3
         update_label=resin-rootB
         ;;
-    *p3)
-        root_dev=${root_part%p3}
-        update_part=${root_dev}p2
+    *3)
+        root_dev=${root_part%3}
+        update_part=${root_dev}2
         update_part_no=2
         update_label=resin-rootA
         ;;

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -238,10 +238,10 @@ function remove_sample_wifi {
 
 function device_type_match {
     # slug in `device-type.json` and `deviceType` in `config.json` should be always the same on proper devices`
-    local slug
+    local deviceslug
     local devicetype
     local match
-    if slug=$(jq .slug $DEVICETYPEJSON) && devicetype=$(jq .deviceType $CONFIGJSON) && [ "$devicetype" = "$slug" ]; then
+    if deviceslug=$(jq .slug "$DEVICETYPEJSON") && devicetype=$(jq .deviceType "$CONFIGJSON") && [ "$devicetype" = "$deviceslug" ]; then
         match=yes
     else
         match=no

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -75,11 +75,7 @@ function log {
             ;;
     esac
     endtime=$(date +%s)
-    if [ "z$LOG" == "zyes" ] && [ -n "$LOGFILE" ]; then
-        printf "[%09d%s%s\n" "$((endtime - starttime))" "][$loglevel]" "$1" | tee -a "$LOGFILE"
-    else
-        printf "[%09d%s%s\n" "$((endtime - starttime))" "][$loglevel]" "$1"
-    fi
+    printf "[%09d%s%s\n" "$((endtime - starttime))" "][$loglevel]" "$1"
     if [ "$loglevel" == "ERROR" ]; then
         progress 100 "ResinOS: Update failed."
         exit 1
@@ -238,6 +234,8 @@ if [ "$LOG" == "yes" ]; then
     mkdir -p "$(dirname "$LOGFILE")"
     echo "================$SCRIPTNAME HEADER START====================" > "$LOGFILE"
     date >> "$LOGFILE"
+    # redirect all logs to the logfile
+    exec 1> "$LOGFILE" 2>&1
 fi
 
 progress 25 "ResinOS: preparing update.."

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -191,6 +191,15 @@ while [[ $# -gt 0 ]]; do
                 log ERROR "\"$1\" argument needs a value."
             fi
             target_version=$2
+            case $target_version in
+                *.prod)
+                    target_version="${target_version%%.prod}"
+                    log "Normalized target version: ${target_version}"
+                    ;;
+                *.dev)
+                    log ERROR "Updating .dev versions is not supported..."
+                    ;;
+            esac
             shift
             ;;
         --supervisor-version)
@@ -267,7 +276,8 @@ else
 fi
 
 # Check OS variant and filter update availability based on that.
-if [ ! "$VARIANT_ID" == "prod" ]; then
+log "VARIANT_ID: ${VARIANT_ID}"
+if [ -n "$VARIANT_ID" ] && [ ! "$VARIANT_ID" == "prod" ]; then
     log ERROR "Only updating production devices..."
 fi
 

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -117,7 +117,7 @@ function upgradeSupervisor() {
 
     if [ -z "$target_supervisor_version" ]; then
         log "No explicit supervisor version was provided, update to default version in target resinOS..."
-        if [ "$STAGING" == "yes" ]; then
+        if [ "$STAGING" = "yes" ]; then
             DEFAULT_SUPERVISOR_VERSION_URL_BASE="https://s3.amazonaws.com/resin-staging-img/"
         else
             DEFAULT_SUPERVISOR_VERSION_URL_BASE="https://s3.amazonaws.com/resin-production-img-cloudformation/"
@@ -389,12 +389,18 @@ fi
 # Stop docker containers
 stop_services
 
-image=resin/resinos:${target_version}-${SLUG}
-
 trap 'error_handler' ERR
 
 log "Getting new OS image..."
 progress 50 "ResinOS: downloading update package..."
+
+if [ "$STAGING" = "yes" ]; then
+    image=resin/resinos-staging:${target_version}-${SLUG}
+else
+    image=resin/resinos:${target_version}-${SLUG}
+fi
+log "Using resinOS image: ${image}"
+
 # Create container for new version
 container=$(docker create "$image" echo export)
 

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -447,6 +447,9 @@ cp -a /tmp/resin-boot/* /mnt/boot/
 # Clearing up
 docker rm "$container"
 
+# Updating supervisor
+upgradeSupervisor
+
 # Switch root partition
 log "Switching root partition..."
 case $SLUG in
@@ -462,9 +465,6 @@ case $SLUG in
         sed -i -e "s/${old_label}/${update_label}/" /mnt/boot/EFI/BOOT/grub.cfg
         ;;
 esac
-
-# Updating supervisor
-upgradeSupervisor
 
 # Reboot into new OS
 sync

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -391,7 +391,7 @@ if version_gt "$VERSION_ID" "2.0.6" &&
         mkdir -p $tools_path
         export PATH=$tools_path:$PATH
         download_url=https://raw.githubusercontent.com/resin-os/meta-resin/v2.3.0/meta-resin-common/recipes-support/resin-device-progress/resin-device-progress/resin-device-progress
-        curl -f -s -L -o $tools_path/resin-device-progress $download_url || log WARNING "Couldn't download tool from $download_url, progress bar won't work, but not aborting..."
+        curl -f -s -L -o $tools_path/resin-device-progress $download_url || log WARN "Couldn't download tool from $download_url, progress bar won't work, but not aborting..."
         chmod 755 $tools_path/resin-device-progress
 else
     log "No resin-device-progress fix is required..."

--- a/upgrade-ssh-2.x.sh
+++ b/upgrade-ssh-2.x.sh
@@ -49,6 +49,12 @@ Options:
         Run ${main_script_name} with --ignore-sanity-checks
         See ${main_script_name} help for more details.
 
+  --nolog
+        Run ${main_script_name} with --nolog
+        See ${main_script_name} help for more details. For running over ssh this is likely
+        recommended, as otherwise the log is just kept on the device, the local log
+        on the computer running the remote updater script will have only log headers.
+
   --no-reboot
         Run ${main_script_name} with --no-reboot . See ${main_script_name} help for more details.
 
@@ -220,6 +226,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         --no-reboot)
             RESINHUP_ARGS+=( "--no-reboot" )
+            ;;
+        --no-reboot)
+            RESINHUP_ARGS+=( "--nolog" )
             ;;
         --no-colors)
             NOCOLORS=yes

--- a/upgrade-ssh-2.x.sh
+++ b/upgrade-ssh-2.x.sh
@@ -45,6 +45,10 @@ Options:
         Run ${main_script_name} with --supervisor-version <SUPERVISOR_VERSION>, use e.g. 6.2.5
         See ${main_script_name} help for more details.
 
+  --ignore-sanity-checks
+        Run ${main_script_name} with --ignore-sanity-checks
+        See ${main_script_name} help for more details.
+
   --no-reboot
         Run ${main_script_name} with --no-reboot . See ${main_script_name} help for more details.
 
@@ -173,6 +177,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         --staging)
             RESINHUP_ARGS+=( "--staging" )
+            ;;
+        --ignore-sanity-checks)
+            RESINHUP_ARGS+=( "--ignore-sanity-checks" )
             ;;
         -u|--uuid)
             if [ -z "$2" ]; then

--- a/upgrade-ssh-2.x.sh
+++ b/upgrade-ssh-2.x.sh
@@ -227,7 +227,7 @@ while [[ $# -gt 0 ]]; do
         --no-reboot)
             RESINHUP_ARGS+=( "--no-reboot" )
             ;;
-        --no-reboot)
+        --nolog)
             RESINHUP_ARGS+=( "--nolog" )
             ;;
         --no-colors)

--- a/upgrade-ssh-2.x.sh
+++ b/upgrade-ssh-2.x.sh
@@ -273,11 +273,12 @@ for uuid in $UUIDS; do
 
     # Connect to device
     echo "Running run-resinhup.sh ${RESINHUP_ARGS[*]} ..." >> "$log_filename"
+    # shellcheck disable=SC2029
     ssh "$SSH_HOST" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Hostname="${uuid}.vpn" "/tmp/${main_script_name}" "${RESINHUP_ARGS[@]}" >> "$log_filename" 2>&1 &
 
     # Manage queue of threads
     PID=$!
-    addtoqueue $PID:$uuid
+    addtoqueue "$PID:$uuid"
     while [ "$NUM" -ge "$MAX_THREADS" ]; do
         checkqueue
         sleep 0.5


### PR DESCRIPTION
The set of changes in this PR:

* The logging function in this file was already able to handle logging to a file (eg. for when the script is invoked through the proxy). Add the relevant setup section and command line flags to actually make use of it.
* being able to use staging resinOS docker hub
* switching order of supervisor update with rootfs switch for bringing upgrade changes closer to each other (and be reversible if the supervisor update fails)
* adding logic to handle the root of Beaglebone and NUC devices properly
* add better logging that saves all logs into the file (including standard output and errors)
* checking if image:tag exists in registry (docker hub) and bail out if not
* remove vulnerable `resin-sample` from the device if present on update #93 
* fix logic of getting APIKEY for some versions where both apikey and deviceapikey is present (probably >=2.0.0 || <2.0.3)
* sanity check for device types