### PR TITLE
ugrade-1.x-to-2.x: changes to go into the self-service HUP

### DIFF
--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -592,6 +592,9 @@ log "Getting new OS image..."
 progress 50 "ResinOS: downloading OS update..."
 # Create container for new version
 CONTAINER=$(docker create ${IMAGE} echo export)
+if [ -z "$CONTAINER" ]; then
+    log ERROR "Could not download target update image..."
+fi
 
 progress 60 "ResinOS: processig update package..."
 # Export container

--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -213,7 +213,7 @@ function stop_all() {
     systemctl stop docker
 }
 
-function image_exsits() {
+function image_exists() {
     # Try to fetch the manifest of a repo:tag combo, to check for the existence of that
     # repo and tag.
     # Currently only works with Docker HUB
@@ -385,7 +385,7 @@ else
 fi
 RESINOS_TAG="${TARGET_VERSION}-${DEVICE}"
 log "Checking for manifest of ${RESINOS_REPO}:${RESINOS_TAG}"
-if [ "$(image_exsits "$RESINOS_REPO" "$RESINOS_TAG")" = "yes" ]; then
+if [ "$(image_exists "$RESINOS_REPO" "$RESINOS_TAG")" = "yes" ]; then
     log "Manifest found, good to go..."
 else
     log ERROR "Cannot find manifest, target image might not exists. Bailing out..."

--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -82,11 +82,7 @@ function log {
             ;;
     esac
     ENDTIME=$(date +%s)
-    if [ "z$LOG" == "zyes" ] && [ -n "$LOGFILE" ]; then
-        printf "[%09d%s%s\n" "$(($ENDTIME - $STARTTIME))" "][$loglevel]" "$1" | tee -a $LOGFILE
-    else
-        printf "[%09d%s%s\n" "$(($ENDTIME - $STARTTIME))" "][$loglevel]" "$1"
-    fi
+    printf "[%09d%s%s\n" "$(($ENDTIME - $STARTTIME))" "][$loglevel]" "$1"
     if [ "$loglevel" == "ERROR" ]; then
         progress 100 "ResinOS: Update failed."
         exit 1
@@ -265,6 +261,8 @@ if [ "$LOG" == "yes" ]; then
     mkdir -p "$(dirname "$LOGFILE")"
     echo "================$SCRIPTNAME HEADER START====================" > "$LOGFILE"
     date >> "$LOGFILE"
+    # redirect all logs to the logfile
+    exec 1> "$LOGFILE" 2>&1
 fi
 
 if [ -z ${TARGET_VERSION+x} ]; then

--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -225,6 +225,15 @@ while [[ $# -gt 0 ]]; do
                 log ERROR "\"$1\" argument needs a value."
             fi
             TARGET_VERSION=$2
+            case $TARGET_VERSION in
+                *.prod)
+                    TARGET_VERSION="${TARGET_VERSION%%.prod}"
+                    log "Normalized target version: ${TARGET_VERSION}"
+                    ;;
+                *.dev)
+                    log ERROR "Updating .dev versions is not supported..."
+                    ;;
+            esac
             shift
             ;;
         --supervisor-version)

--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -488,7 +488,7 @@ mkfs.ext4 -F ${root_dev}p3
 mkdir -p /tmp/backup
 mount ${root_dev}p3 /tmp/backup
 log "Backing up resin-data..."
-(cd /mnt/data; tar -zcf /tmp/backup/resin-data.tar.gz resin-data)
+(cd /mnt/data; tar -zcf /tmp/backup/resin-data.tar.gz resin-data || log ERROR "Could not back up resin-data...")
 
 # Unmount p6
 log "Unmounting filesystems..."

--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -101,6 +101,16 @@ function upgradeSupervisor() {
     # the tools shipped with the hostOS.
     log "Supervisor update start..."
 
+    if version_gt "$TARGET_VERSION" "2.4.0+rev0" &&
+        version_gt "2.7.3+rev1" "$TARGET_VERSION" &&
+        [ -z "$TARGET_SUPERVISOR_VERSION" ] ; then
+        # Fixing up supervisor version https://github.com/resin-io/resin-supervisor/issues/495
+        # by selecting the first fixed supervisor after the issues
+        # Needs to apply to version 2.4.2+rev1 <= version < 2.7.3+rev1;
+        # only if no explicit sypervisor is set
+        TARGET_SUPERVISOR_VERSION="6.3.5"
+    fi
+
     if [ -z "$TARGET_SUPERVISOR_VERSION" ]; then
         log "No explicit supervisor version was provided, update to default version in target resinOS..."
         if [ "$STAGING" = "yes" ]; then

--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -267,6 +267,9 @@ progress 5 "ResinOS: update preparation..."
 # Check board support
 case $SLUG in
     beaglebone*)
+        # increase the minimum hostOS version as Beaglebones have an eMMC bug
+        # that would break hup on docker pull with a nasty error for versions below this
+        MIN_HOSTOS_VERSION=1.30.1
         MIN_TARGET_VERSION=2.2.0+rev1
         # In 2.x there is only a single device type
         DEVICE=beaglebone-black

--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -203,6 +203,48 @@ function stop_all() {
     systemctl stop docker
 }
 
+function image_exsits() {
+    # Try to fetch the manifest of a repo:tag combo, to check for the existence of that
+    # repo and tag.
+    # Currently only works with Docker HUB
+    # The return value is "no" if can't access that manifest, and "yes" if we can find it
+    local REPO=$1
+    local TAG=$2
+    local exists=no
+    local REGISTRY_URL="https://registry.hub.docker.com/v2"
+    local MANIFEST="${REGISTRY_URL}/${REPO}/manifests/${TAG}"
+    local response
+    # Check
+    response=$(curl --write-out "%{http_code}" --silent --output /dev/null "${MANIFEST}")
+    if [ "$response" = 401 ]; then
+        # 401 is "Unauthorized", have to grab the access tokens from the provided endpoint
+        local auth_header
+        local realm
+        local service
+        local scope
+        local token
+        local response_auth
+        auth_header=$(curl -I --silent "${MANIFEST}" |grep Www-Authenticate)
+        # The auth_header looks as
+        # Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:resin/resinos:pull"
+        # shellcheck disable=SC2001
+        realm=$(echo "$auth_header" | sed 's/.*realm="\([^,]*\)",.*/\1/' )
+        # shellcheck disable=SC2001
+        service=$(echo "$auth_header" | sed 's/.*,service="\([^,]*\)",.*/\1/' )
+        # shellcheck disable=SC2001
+        scope=$(echo "$auth_header" | sed 's/.*,scope="\([^,]*\)".*/\1/' )
+        # Grab the token from the appropriate address, and retry the manifest query with that
+        token=$(curl --silent "${realm}?service=${service}&scope=${scope}" | jq -r '.access_token')
+        response_auth=$(curl --write-out "%{http_code}" --silent --output /dev/null -H "Authorization: Bearer ${token}" "${MANIFEST}")
+        if [ "$response_auth" = 200 ]; then
+            exists=yes
+        fi
+    elif [ "$response" = 200 ]; then
+        exists=yes
+    fi
+    echo "${exists}"
+}
+
 ###
 # Script start
 ###
@@ -314,6 +356,19 @@ fi
 
 # Translate version to one docker will accept as part of an image name
 TARGET_VERSION=$(echo "$TARGET_VERSION" | tr + _)
+# Checking whether the target versionis available to download
+if [ "$STAGING" = "yes" ]; then
+    RESINOS_REPO="resin/resinos-staging"
+else
+    RESINOS_REPO="resin/resinos"
+fi
+RESINOS_TAG="${TARGET_VERSION}-${DEVICE}"
+log "Checking for manifest of ${RESINOS_REPO}:${RESINOS_TAG}"
+if [ "$(image_exsits "$RESINOS_REPO" "$RESINOS_TAG")" = "yes" ]; then
+    log "Manifest found, good to go..."
+else
+    log ERROR "Cannot find manifest, target image might not exists. Bailing out..."
+fi
 
 # Find boot path
 boot_path=$(findmnt -n --raw --evaluate --output=target LABEL=resin-boot)
@@ -585,11 +640,7 @@ systemctl start docker
 # Remount backup dir
 mount ${root_dev}p3 /tmp/backup
 
-if [ "$STAGING" = "yes" ]; then
-    IMAGE=resin/resinos-staging:${TARGET_VERSION}-${DEVICE}
-else
-    IMAGE=resin/resinos:${TARGET_VERSION}-${DEVICE}
-fi
+IMAGE="${RESINOS_REPO}:${RESINOS_TAG}"
 log "Using resinOS image: ${IMAGE}"
 
 BACKUPARCHIVE=/tmp/backup/newos.tar.gz

--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -486,7 +486,12 @@ log "Switching connman to bind mounted state dir..."
 mkdir -p /tmp/connman
 cp -a /var/lib/connman/* /tmp/connman/
 # Versions before 1.20 need this to prevent dropping VPN
-sed -i -e 's/NetworkInterfaceBlacklist=docker,veth,tun,p2p/NetworkInterfaceBlacklist=docker,veth,tun,p2p,resin-vpn/' /etc/connman/main.conf
+if grep -q 'NetworkInterfaceBlacklist=.*resin-vpn.*'  /etc/connman/main.conf ; then
+    log "resin-vpn is already blacklisted in connman configuration"
+else
+    log "resin-vpn needs to be blacklisted in connman configuration"
+    sed -i -e 's/NetworkInterfaceBlacklist=\(.*\)/NetworkInterfaceBlacklist=resin-vpn,\1/' /etc/connman/main.conf
+fi
 mount -o bind /tmp/connman /var/lib/connman
 # some systems require daemon-reload to correctly restart connman later
 systemctl daemon-reload

--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -596,7 +596,7 @@ if [ -z "$CONTAINER" ]; then
     log ERROR "Could not download target update image..."
 fi
 
-progress 60 "ResinOS: processig update package..."
+progress 60 "ResinOS: processing update package..."
 # Export container
 log "Starting docker export"
 docker export ${CONTAINER} | gzip > ${BACKUPARCHIVE}

--- a/upgrade-ssh-1.x-to-2.x.sh
+++ b/upgrade-ssh-1.x-to-2.x.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+
+main_script_name="upgrade-1.x-to-2.x.sh"
+RESINHUP_ARGS=()
+UUIDS=""
+SSH_HOST=""
+NOCOLORS=no
+FAILED=0
+
+NUM=0
+QUEUE=""
+MAX_THREADS=5
+
+# Help function
+function help {
+    cat << EOF
+Wrapper to run host OS updates on fleet of devices over ssh.
+$0 <OPTION>
+
+Options:
+  -h, --help
+        Display this help and exit.
+
+  --staging
+        Do this update for devices in staging.
+        By default resinhup assumes the devices are in production.
+
+  -u <UUID>, --uuid <UUID>
+        Update this UUID. Multiple -u can be provided to updated mutiple devices.
+
+  -s <SSH_HOST>, --ssh-host <SSH_HOST>
+        SSH host to be used in ssh connections (e.g. resin or resinstaging).
+
+  -m <MAX_THREADS>, --max-threads <MAX_THREADS>
+        Maximum number of threads to be used when updating devices in parallel. Useful to
+        not network bash network if devices are in the same one. If value is 0, all
+        updates will start in parallel.
+
+  --hostos-version <HOSTOS_VERSION>
+        Run ${main_script_name} with --hostos-version <HOSTOS_VERSION>, use e.g. 2.2.0+rev1
+        See ${main_script_name} help for more details.
+        This is a mandatory argument.
+
+  --supervisor-version <SUPERVISOR_VERSION>
+        Run ${main_script_name} with --supervisor-version <SUPERVISOR_VERSION>, use e.g. 6.2.5
+        See ${main_script_name} help for more details.
+
+  --no-reboot
+        Run ${main_script_name} with --no-reboot . See ${main_script_name} help for more details.
+
+  --no-colors
+        Avoid terminal colors.
+EOF
+}
+
+# Log function helper
+function log {
+    local COL
+    local COLEND='\e[0m'
+    local loglevel=LOG
+
+    case $1 in
+        ERROR)
+            COL='\e[31m'
+            loglevel=ERR
+            shift
+            ;;
+        WARN)
+            COL='\e[33m'
+            loglevel=WRN
+            shift
+            ;;
+        SUCCESS)
+            COL='\e[32m'
+            loglevel=LOG
+            shift
+            ;;
+        *)
+            COL=$COLEND
+            loglevel=LOG
+            ;;
+    esac
+
+    if [ "$NOCOLORS" == "yes" ]; then
+        COLEND=''
+        COL=''
+    fi
+
+    ENDTIME=$(date +%s)
+    printf "${COL}[%09d%s%s${COLEND}\n" "$((ENDTIME - STARTTIME))" "][$loglevel]" "$1"
+    if [ "$loglevel" == "ERR" ]; then
+        exit 1
+    fi
+}
+
+cleanstop() {
+    log WARN "Force close requested. Waiting for already started updates... Please wait!"
+    while [ -n "$QUEUE" ]; do
+        checkqueue
+        sleep 0.5
+    done
+    wait
+    log ERROR "Forced stop."
+    exit 1
+}
+trap 'cleanstop' SIGINT SIGTERM
+
+function addtoqueue {
+    NUM=$((NUM+1))
+    QUEUE="$QUEUE $1"
+}
+
+function regeneratequeue {
+    OLDREQUEUE=$QUEUE
+    QUEUE=""
+    NUM=0
+    for entry in $OLDREQUEUE; do
+        PID=$(echo "$entry" | cut -d: -f1)
+        if [ -d "/proc/$PID"  ] ; then
+            QUEUE="$QUEUE $entry"
+            NUM=$((NUM+1))
+        fi
+    done
+}
+
+function checkqueue {
+    OLDCHQUEUE=$QUEUE
+    for entry in $OLDCHQUEUE; do
+        local _PID
+        _PID=$(echo "$entry" | cut -d: -f1)
+        if [ ! -d "/proc/$_PID" ] ; then
+            wait "$_PID"
+            local _exitcode=$?
+            local _UUID
+            _UUID=$(echo "$entry" | cut -d: -f2)
+            if [ "$_exitcode" != "0" ]; then
+                log WARN "Updating $_UUID failed."
+                FAILED=1
+            else
+                log SUCCESS "Updating $_UUID succeeded."
+            fi
+            regeneratequeue
+            break
+        fi
+    done
+}
+
+#
+# MAIN
+#
+
+# Get the absolute script location
+pushd "$(dirname "$0")" > /dev/null 2>&1
+SCRIPTPATH=$(pwd)
+popd > /dev/null 2>&1
+
+# Tools we need on device
+UPDATE_TOOLS=(
+"$SCRIPTPATH/${main_script_name}"
+)
+
+# Log timer
+STARTTIME=$(date +%s)
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    arg="$1"
+
+    case $arg in
+        -h|--help)
+            help
+            exit 0
+            ;;
+        --staging)
+            RESINHUP_ARGS+=( "--staging" )
+            ;;
+        -u|--uuid)
+            if [ -z "$2" ]; then
+                log ERROR "\"$1\" argument needs a value."
+            fi
+            UUIDS="$UUIDS $2"
+            shift
+            ;;
+        -s|--ssh-host)
+            if [ -z "$2" ]; then
+                log ERROR "\"$1\" argument needs a value."
+            fi
+            SSH_HOST=$2
+            shift
+            ;;
+        -m|--max-threads)
+            if [ -z "$2" ]; then
+               log ERROR "\"$1\" argument needs a value."
+            fi
+            MAX_THREADS=$2
+            shift
+            ;;
+        --hostos-version)
+            if [ -z "$2" ]; then
+                log ERROR "\"$1\" argument needs a value."
+            fi
+            HOSTOS_VERSION=$2
+            RESINHUP_ARGS+=( "--hostos-version $HOSTOS_VERSION" )
+            shift
+            ;;
+        --supervisor-version)
+            if [ -z "$2" ]; then
+                log ERROR "\"$1\" argument needs a value."
+            fi
+            SUPERVISOR_VERSION=$2
+            RESINHUP_ARGS+=( "--supervisor-version $SUPERVISOR_VERSION" )
+            shift
+            ;;
+        --no-reboot)
+            RESINHUP_ARGS+=( "--no-reboot" )
+            ;;
+        --no-colors)
+            NOCOLORS=yes
+            ;;
+        *)
+            log ERROR "Unrecognized option $1."
+            ;;
+    esac
+    shift
+done
+
+# Check argument(s)
+if [ -z "$UUIDS" ] || [ -z "$SSH_HOST" ]; then
+    log ERROR "No UUID and/or SSH_HOST specified."
+fi
+
+CURRENT_UPDATE=0
+NR_UPDATES=$(echo "$UUIDS" | wc -w)
+
+# 0 threads means Parallelise everything
+if [ "$MAX_THREADS" -eq 0 ]; then
+    MAX_THREADS=$NR_UPDATES
+fi
+
+# Update each UUID
+for uuid in $UUIDS; do
+    CURRENT_UPDATE=$((CURRENT_UPDATE+1))
+
+    log "[$CURRENT_UPDATE/$NR_UPDATES] Updating $uuid on $SSH_HOST."
+    log_filename="$uuid.upgrade2x.log"
+
+    if ! ssh "$SSH_HOST" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o "Hostname=${uuid}.vpn" exit > /dev/null 2>&1; then
+        log WARN "[$CURRENT_UPDATE/$NR_UPDATES] Can't connect to device. Skipping..."
+        continue
+    fi
+
+    # Transfer the scripts
+    if ! scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Hostname="${uuid}.vpn" "${UPDATE_TOOLS[@]}" "$SSH_HOST":/tmp/ > "$log_filename" 2>&1; then
+        log WARN "[$CURRENT_UPDATE/$NR_UPDATES] Could not scp needed tools to device. Skipping..."
+        continue
+    fi
+
+    # Connect to device
+    echo "Running run-resinhup.sh ${RESINHUP_ARGS[*]} ..." >> "$log_filename"
+    ssh "$SSH_HOST" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Hostname="${uuid}.vpn" "/tmp/${main_script_name}" "${RESINHUP_ARGS[@]}" >> "$log_filename" 2>&1 &
+
+    # Manage queue of threads
+    PID=$!
+    addtoqueue $PID:$uuid
+    while [ "$NUM" -ge "$MAX_THREADS" ]; do
+        checkqueue
+        sleep 0.5
+    done
+done
+
+# Wait for all threads
+log "Waiting for all threads to finish..."
+while [ -n "$QUEUE" ]; do
+    checkqueue
+    sleep 0.5
+done
+wait
+
+if [ $FAILED -eq 1 ]; then
+    log ERROR "At least one device failed to update."
+fi
+
+# Success
+exit 0

--- a/upgrade-ssh-1.x-to-2.x.sh
+++ b/upgrade-ssh-1.x-to-2.x.sh
@@ -45,6 +45,12 @@ Options:
         Run ${main_script_name} with --supervisor-version <SUPERVISOR_VERSION>, use e.g. 6.2.5
         See ${main_script_name} help for more details.
 
+    --nolog
+          Run ${main_script_name} with --nolog
+          See ${main_script_name} help for more details. For running over ssh this is likely
+          recommended, as otherwise the log is just kept on the device, the local log
+          on the computer running the remote updater script will have only log headers.
+
   --no-reboot
         Run ${main_script_name} with --no-reboot . See ${main_script_name} help for more details.
 
@@ -213,6 +219,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         --no-reboot)
             RESINHUP_ARGS+=( "--no-reboot" )
+            ;;
+        --nolog)
+            RESINHUP_ARGS+=( "--nolog" )
             ;;
         --no-colors)
             NOCOLORS=yes


### PR DESCRIPTION
* Exit properly when switching root partition
* Source profile to get proper path information
* Enable loging (to /tmp/ as for 1.x->2.x the only filesystem  that does not
  change in the process)
* Allow pulling from the staging resinOS Docker HUB repository
* Add script to call the updater through ssh (optional, for manual updates)
* Increase minimum hostos starting version for BB, so that we avoid the eMMC bug
* Bail out better if the resinos image download fails (instead of silently dying)
* Better logging on the device
* Checking if image:tag exists in registry (docker hub) and bail out if not
* Fix start-resin-supervisor for versions that have broken logic
* Log error properly when resin-data backup fails (e.g. if backup larger than available space to back up)
* For releases that come with potentialy broken supervisor (6.2.0-6.3.4), upgrade to the next available supervisor (6.3.5)