### PR TITLE
upgrade-1.x-to-2.x: set to be deleted partitions to read only and flush buffer

### DIFF
--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -526,6 +526,11 @@ fi
 # Unmount p1
 umount "${boot_path}"
 
+# Set soon-to-be-removed block devices to read-only, and flush the buffers
+blockdev --setro ${root_dev}p6
+blockdev --setro ${root_dev}p5
+blockdev --flushbufs ${root_dev}
+
 log "Creating new partition table stage 1..."
 # Delete partitions 4-6
 parted -s $root_dev rm 6


### PR DESCRIPTION
In some rare, and hard-to-reproduce cases, when parted removes a partition,the partition table information fails to update, because maybe the partition is somehow still in use even if it was unmounted successfully.

Trying to prevent that case by setting the soon-to-be-removed partitions to read-only and flushing the device buffers, before removing the partition.