### PR TITLE
upgrade-1.x-to-2.x: supervisor bootstrap add highest target version

### DIFF
--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -737,8 +737,9 @@ tar -x -C /tmp -f ${FSARCHIVE} quirks
 cp -a /tmp/quirks/* /tmp/rootB/
 rm -rf /tmp/quirks
 
-# Fix supervisor bootstrap issue
-if version_gt "$TARGET_VERSION" "2.4.2+rev1" || [ "$TARGET_VERSION" = "2.4.2+rev1" ]; then
+# Fix supervisor bootstrap issue between 2.4.2 and 2.7.3 versions
+# https://github.com/resin-os/meta-resin/pull/877
+if version_gt "$TARGET_VERSION" "2.4.2" && version_gt "2.7.3" "$TARGET_VERSION"; then
     fix_supervisor_bootstrap
 fi
 


### PR DESCRIPTION
Define a top version where to apply the supervisor bootstrap fix, now that the fix was merged and released in meta-resin 2.7.3.

Connects-to: https://github.com/resin-os/meta-resin/pull/877

(tested with update 1.30.1->2.4.2 which needs fix, and 1.26.0->2.7.5 which does not need fix)