### PR TITLE
upgrade-scripts: fix indentations

### DIFF
--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -411,12 +411,12 @@ if version_gt $VERSION $MIN_HOSTOS_VERSION || [ "$VERSION" == $MIN_HOSTOS_VERSIO
     log "Starting Host OS version $VERSION OK."
 else
     case $VERSION in
-	1.*)
-	    log ERROR "Starting Host OS version \"$VERSION\" too low, need \"$MIN_HOSTOS_VERSION\" or greater."
-	    ;;
-	*)
-	    log ERROR "Starting Host OS version \"$VERSION\" too high."
-	    ;;
+    1.*)
+        log ERROR "Starting Host OS version \"$VERSION\" too low, need \"$MIN_HOSTOS_VERSION\" or greater."
+        ;;
+    *)
+        log ERROR "Starting Host OS version \"$VERSION\" too high."
+        ;;
     esac
 fi
 
@@ -500,17 +500,17 @@ if ! version_gt $VERSION $PREFERRED_HOSTOS_VERSION && ! [ "$VERSION" == $PREFERR
     mkdir -p $tools_path
     export PATH=$tools_path:$PATH
     case $BINARY_TYPE in
-	arm)
-	    download_uri=https://github.com/resin-os/resinhup/raw/master/upgrade-binaries/$BINARY_TYPE
-	    for binary in $tools_binaries; do
-		log "Installing $binary..."
-		curl -f -s -L -o $tools_path/$binary $download_uri/$binary || log ERROR "Couldn't download tool from $download_uri/$binary, aborting."
-		chmod 755 $tools_path/$binary
-	    done
-	    ;;
-	*)
-	    log ERROR "Binary type $BINARY_TYPE not supported."
-	    ;;
+        arm)
+            download_uri=https://github.com/resin-os/resinhup/raw/master/upgrade-binaries/$BINARY_TYPE
+            for binary in $tools_binaries; do
+                log "Installing $binary..."
+                curl -f -s -L -o $tools_path/$binary $download_uri/$binary || log ERROR "Couldn't download tool from $download_uri/$binary, aborting."
+                chmod 755 $tools_path/$binary
+            done
+            ;;
+        *)
+            log ERROR "Binary type $BINARY_TYPE not supported."
+            ;;
     esac
 fi
 

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -370,12 +370,12 @@ fi
 if [ -n "$target_version" ]; then
     case $target_version in
         2.*)
-	    if ! version_gt "$target_version" "$minimum_target_version" &&
-		    ! [ "$target_version" == "$minimum_target_version" ]; then
-		log ERROR "Target OS version \"$target_version\" too low, please use \"$minimum_target_version\" or above."
-	    else
-		log "Target OS version \"$target_version\" OK."
-	    fi
+        if ! version_gt "$target_version" "$minimum_target_version" &&
+            ! [ "$target_version" == "$minimum_target_version" ]; then
+        log ERROR "Target OS version \"$target_version\" too low, please use \"$minimum_target_version\" or above."
+        else
+        log "Target OS version \"$target_version\" OK."
+        fi
             ;;
         *)
             log ERROR "Target OS version \"$target_version\" not supported."


### PR DESCRIPTION
Some parts had mixed tabs/4-spaces indentations, which made the script difficult to use manually. Unify on 4-spaces.