### PR TITLE
upgrade-2.x: adding support for iot2000 board

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -648,7 +648,7 @@ case $SLUG in
     raspberry*)
         binary_type=arm
         ;;
-    intel-nuc|up-board)
+    intel-nuc|iot2000|up-board)
         binary_type=x86
         ;;
     *)


### PR DESCRIPTION
First release of iot2000 is 2.7.6+rev1, resinhup tested to work starting from that release.