### PR TITLE
upgrade-2.x: remove supervisor database after upgrade for some versions

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -198,6 +198,10 @@ function upgrade_supervisor() {
                     update-resin-supervisor
                     stop_services
                     remove_containers
+                    if version_gt "6.5.9" "${target_supervisor_version}" ; then
+                        log "Removing supervisor database for migration"
+                        rm /resin-data/resin-supervisor/database.sqlite || true
+                    fi
                 else
                     log ERROR "Couldn't extract supervisor vars..."
                 fi


### PR DESCRIPTION
Some supervisor versions are not great at database migration, and after HUP might not start up properly. Remove the database for the affected versions' updates as a workaround. Fixed such issues in supervisor v6.5.7 and v6.5.9.

Change-type: patch