### PR TITLE
upgrade-2.x: add support for Jetson TX2 and related devices

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -706,6 +706,9 @@ case $SLUG in
     raspberry*)
         binary_type=arm
         ;;
+    jetson-tx2|skx2)
+        binary_type=arm
+        ;;
     intel-nuc|iot2000|up-board)
         binary_type=x86
         ;;


### PR DESCRIPTION
Only support versions >=2.7.4. Tested with 2.7.4+rev1->2.7.4+rev1 and 2.7.4+rev1->2.8.1+rev2 updates

Change-type: minor

Connects-to: #138 
---- Autogenerated Waffleboard Connection: Connects to #138