### PR TITLE
upgrade-2.x: add support for ts4900 device type

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -709,6 +709,9 @@ case $SLUG in
     jetson-tx2|skx2)
         binary_type=arm
         ;;
+    ts4900)
+        binary_type=arm
+        ;;
     intel-nuc|iot2000|up-board)
         binary_type=x86
         ;;


### PR DESCRIPTION
Applicable for resinOS >=2.4.1, as the storage driver has changed with that version.

Change-type: minor

Connects-to: #127 
---- Autogenerated Waffleboard Connection: Connects to #127