### PR TITLE
upgrade-2.x: add QEMU support for resinHUP scripts

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -712,7 +712,7 @@ case $SLUG in
     ts4900)
         binary_type=arm
         ;;
-    intel-nuc|iot2000|up-board)
+    intel-nuc|iot2000|up-board|qemux86*)
         binary_type=x86
         ;;
     *)


### PR DESCRIPTION
Should work starting from resinOS 2.9.2+rev1 on QEMU, though might want to limit in practice to 2.9.3+rev1 and upwards (as 2.9.2 is missing `resin-device-progress`)

Change-type: minor