### PR TITLE
upgrade-2.x: add support for Intel Edison updates on resinOS 2.x

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -727,7 +727,7 @@ case $SLUG in
     ts4900)
         binary_type=arm
         ;;
-    intel-nuc|iot2000|up-board|qemux86*)
+    intel-edison|intel-nuc|iot2000|up-board|qemux86*)
         binary_type=x86
         ;;
     *)
@@ -743,8 +743,10 @@ fi
 log "Loading info from device-type.json"
 if [ -f /mnt/boot/device-type.json ]; then
     DEVICETYPEJSON=/mnt/boot/device-type.json
+elif [ -f /resin-boot/device-type.json ]; then
+    DEVICETYPEJSON=/resin-boot/device-type.json
 else
-    log ERROR "Don't know where config.json is."
+    log ERROR "Don't know where device-type.json is."
 fi
 # If the user api key exists we use it instead of the deviceApiKey as it means we haven't done the key exchange yet
 # shellcheck disable=SC2046


### PR DESCRIPTION
The update should work target resinOS versions >=2.9.7, and production versions should be supported for the starting version.

Extra `device-type.json` check is added, as on older resinOS versions that file was not shipped in the boot partition by default.

Change-type: minor