### PR TITLE
upgrade-2.x: add flag to stop user application before updates

### DIFF
--- a/upgrade-ssh-2.x.sh
+++ b/upgrade-ssh-2.x.sh
@@ -63,6 +63,9 @@ Options:
         Run ${main_script_name} with --supervisor-version <SUPERVISOR_VERSION>, use e.g. 6.2.5
         See ${main_script_name} help for more details.
 
+  --stop-all
+        Run ${main_script_name} with --stop-all, to stop running containers before the update.
+
   --ignore-sanity-checks
         Run ${main_script_name} with --ignore-sanity-checks
         See ${main_script_name} help for more details.
@@ -265,6 +268,10 @@ while [[ $# -gt 0 ]]; do
             fi
             RESINOS_TAG=$2
             RESINHUP_ARGS+=( "--resinos-tag $RESINOS_TAG" )
+            shift
+            ;;
+        --stop-all)
+            RESINHUP_ARGS+=( "--stop-all" )
             shift
             ;;
         --supervisor-version)


### PR DESCRIPTION
The flag let resinHUP to stop user application before proceeding to the actual update. This can be useful in case for example running manual host OS updates on devices whose application is known to interfere in some way.

Tested on a number of upgrades from & to 2.3.0 / 2.7.8 / 2.9.7 on a Raspberry Pi.

Change-type: minor