### PR TITLE
upgrade scripts: use lockfile to prevent multiple updates running

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -36,6 +36,18 @@ fi
 # Helper functions
 ###
 
+# Preventing running multiple instances of upgrades running
+LOCKFILE="/var/lock/resinhup"
+LOCKFD=99
+## Private functions
+_lock()             { flock "-$1" $LOCKFD; }
+_no_more_locking()  { _lock u; _lock xn && rm -f $LOCKFILE; }
+_prepare_locking()  { eval "exec $LOCKFD>\"$LOCKFILE\""; trap _no_more_locking EXIT; }
+# Run on start
+_prepare_locking
+# Public functions
+exlock_now()        { _lock xn; }  # obtain an exclusive lock immediately or fail
+
 # Dashboard progress helper
 function progress {
     percentage=$1
@@ -621,6 +633,9 @@ function finish_up() {
 ###
 # Script start
 ###
+
+# Try to get lock, and exit if cannot, meaning another instance is running already
+exlock_now || exit 9
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
Adding locking functionality to the update scripts based on this method: https://stackoverflow.com/a/1985512

Locking at the very beginning of the update, and when the updater exits, the lock should be released.

Change-type: minor
Connects-to: #101 
---- Autogenerated Waffleboard Connection: Connects to #101