### PR TITLE
upgrade_2.x: change when to remove containers for supervisor updates

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -216,8 +216,8 @@ function upgrade_supervisor() {
                     progress 90 "Running supervisor update"
                     update-resin-supervisor
                     stop_services
-                    remove_containers
                     if version_gt "6.5.9" "${target_supervisor_version}" ; then
+                        remove_containers
                         log "Removing supervisor database for migration"
                         rm /resin-data/resin-supervisor/database.sqlite || true
                     fi


### PR DESCRIPTION
That container removal step is unnecessary for most supervisor updates,
and in fact it will prevent a successful update on resinOS 2.12.0,
due to a balena issue.

Solution is not to do that step unless it's necessary.

Change-type: patch