### PR TITLE
upgrade-1.x/1.x-to-2.x/2.x: lockfile improvements

### DIFF
--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -26,14 +26,12 @@ STARTTIME=$(date +%s)
 ###
 
 # Preventing running multiple instances of upgrades running
-LOCKFILE="/var/lock/resinhup"
+LOCKFILE="/var/lock/resinhup.lock"
 LOCKFD=99
 ## Private functions
 _lock()             { flock -$1 $LOCKFD; }
 _no_more_locking()  { _lock u; _lock xn && rm -f $LOCKFILE; }
 _prepare_locking()  { eval "exec $LOCKFD>\"$LOCKFILE\""; trap _no_more_locking EXIT; }
-# Run on start
-_prepare_locking
 # Public functions
 exlock_now()        { _lock xn; }  # obtain an exclusive lock immediately or fail
 
@@ -347,9 +345,6 @@ function check_btrfs_umount() {
 # Script start
 ###
 
-# Try to get lock, and exit if cannot, meaning another instance is running already
-exlock_now || exit 9
-
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     arg="$1"
@@ -397,6 +392,11 @@ while [[ $# -gt 0 ]]; do
     esac
     shift
 done
+
+# Run on start
+_prepare_locking
+# Try to get lock, and exit if cannot, meaning another instance is running already
+exlock_now || exit 9
 
 # LOGFILE init and header
 if [ "$LOG" == "yes" ]; then

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -37,14 +37,12 @@ fi
 ###
 
 # Preventing running multiple instances of upgrades running
-LOCKFILE="/var/lock/resinhup"
+LOCKFILE="/var/lock/resinhup.lock"
 LOCKFD=99
 ## Private functions
 _lock()             { flock "-$1" $LOCKFD; }
 _no_more_locking()  { _lock u; _lock xn && rm -f $LOCKFILE; }
 _prepare_locking()  { eval "exec $LOCKFD>\"$LOCKFILE\""; trap _no_more_locking EXIT; }
-# Run on start
-_prepare_locking
 # Public functions
 exlock_now()        { _lock xn; }  # obtain an exclusive lock immediately or fail
 
@@ -634,9 +632,6 @@ function finish_up() {
 # Script start
 ###
 
-# Try to get lock, and exit if cannot, meaning another instance is running already
-exlock_now || exit 9
-
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     arg="$1"
@@ -720,6 +715,11 @@ while [[ $# -gt 0 ]]; do
     esac
     shift
 done
+
+# Run on start
+_prepare_locking
+# Try to get lock, and exit if cannot, meaning another instance is running already
+exlock_now || exit 9
 
 if [ -n "$RESINOS_REPO_STAGING" ]; then
     RESINOS_REPO="${RESINOS_REPO_STAGING}"


### PR DESCRIPTION
* Adding lockfile support to 1.x updater
* Move internal locking point within the scripts, so it happens after
  command line parsing, otherwise user cannot view the help of the script
* Rename lockfile, as was assumed that `.lock` extension is automatically
  applied, but that's a wrong assumption

Change-type: patch