### PR TITLE
upgrade-2.x: upgrading a `.dev` device switched from error to warning

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -826,7 +826,7 @@ fi
 # Check OS variant and filter update availability based on that.
 log "VARIANT_ID: ${VARIANT_ID}"
 if [ -n "$VARIANT_ID" ] && [ ! "$VARIANT_ID" == "prod" ]; then
-    log ERROR "Only updating production devices..."
+    log WARN "Updating a non-production device..."
 fi
 
 # Check host OS version


### PR DESCRIPTION
Treating that update attempt as an error is likely not really helpful. Since the resin.io dashboard does not enable updating `.dev` devices anyways, but in support we do some updates for dev device updates (which is then intentional and cleared with the users), if we just warn in the logs should be enough for the time being, until a better story is developed with .dev updates in general.

Change-type: minor