### PR TITLE
upgrade-2.x: add new flag to assume supported device

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -108,6 +108,12 @@ Options:
         This flags turns sanity check failures from errors into warnings only, so the
         the update is not stopped if there are any failures.
         Use with extreme caution!
+
+  --assume-supported
+        Assuming supported device, and disabling the relevant check.
+        Only enabled for updates that use update hooks, otherwise the updater
+        wouldn't know how to switch partitions, so only available for resinOS ${minimum_hostapp_target_version}.
+        You probably want to supply your own '--resinos-tag' as well in this case.
 EOF
 }
 
@@ -714,6 +720,9 @@ while [[ $# -gt 0 ]]; do
         --stop-all)
             STOP_ALL="yes"
             ;;
+        --assume-supported)
+            SUPPORTED="yes"
+            ;;
         *)
             log WARN "Unrecognized option $1."
             ;;
@@ -770,7 +779,12 @@ case $SLUG in
         binary_type=x86
         ;;
     *)
-        log ERROR "Unsupported board type $SLUG."
+        if { version_gt "$target_version" "$minimum_hostapp_target_version" || [ "$target_version" == "$minimum_hostapp_target_version" ]; } &&
+            [ -n "${SUPPORTED}" ]; then
+                log WARN "Assuming supported device (with extracted slug of ${SLUG})."
+        else
+            log ERROR "Unsupported board type $SLUG."
+        fi
 esac
 
 log "Loading info from config.json"

--- a/upgrade-ssh-2.x.sh
+++ b/upgrade-ssh-2.x.sh
@@ -70,6 +70,10 @@ Options:
         Run ${main_script_name} with --ignore-sanity-checks
         See ${main_script_name} help for more details.
 
+  --assume-supported
+        Run ${main_script_name} with --assume-supported
+        See ${main_script_name} help for more details.
+
   --nolog
         Run ${main_script_name} with --nolog
         See ${main_script_name} help for more details. For running over ssh this is likely
@@ -211,6 +215,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         --ignore-sanity-checks)
             RESINHUP_ARGS+=( "--ignore-sanity-checks" )
+            ;;
+        --assume-supported)
+            RESINHUP_ARGS+=( "--assume-supported" )
             ;;
         -u|--uuid)
             if [ -z "$2" ]; then


### PR DESCRIPTION
The flag skips SLUG check for device support, and allows update, but only for target versions that are using the update hooks, thus this updater does not need to explicitly know how to switch the root partition.

Change-type: minor