### PR TITLE
upgrade-1.x-to-2.x/-2.x: replace $SECONDS with iteration counter

### DIFF
--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -331,9 +331,10 @@ function fix_supervisor_bootstrap {
 function check_btrfs_umount() {
     # Check whether /data has been correctly umounted, which is the only btrfs
     # partition;  if not, then bail out before anything's destroyed
-    local timeout_seconds=$((SECONDS+30));
+    # Timeout is 30s (=150*0.2s)
+    local timeout_iterations=0
     while pidof btrfs-worker > /dev/null; do
-        if [ $SECONDS -gt ${timeout_seconds} ]; then
+        if [ $((timeout_iterations)) -ge 150 ]; then
             log ERROR "Timing out waiting for btrfs file system to be umounted..."
         fi
         sleep 0.2


### PR DESCRIPTION
$SECONDS is not resilient to OS time changes (eg. time synchroniziation) happening during the run of the script, which can cause issues with the way timeout was checked in the scripts.

Switch to iteration count with known sleep time, which is robust against to underlying time changes.

Tested with updates on a VirtualBox NUC:

* 1.26.0->2.2.0
* 2.2.0->2.7.8->2.9.7
* 2.2.0->2.7.8 (legacy update method)->2.9.7

These updates exercise all the modified code paths.

Change-type: patch