### PR TITLE
upgrade-2.x: clean up after in-container resinOS updates

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -407,6 +407,9 @@ function in_container_hostapp_update {
       "${update_package}" \
       /bin/bash -c 'storage_driver=$(cat /boot/storage-driver) ; DOCKER_TMPDIR=/mnt/data/resinhup/tmp/ '"${target_dockerd}"' --storage-driver=$storage_driver --data-root='"${inactive}"'/'"${target_docker_cmd}"' --host=unix:///var/run/'"${target_docker_cmd}"'-host.sock --pidfile=/var/run/'"${target_docker_cmd}"'-host.pid --exec-root=/var/run/'"${target_docker_cmd}"'-host --bip=10.114.201.1/24 --fixed-cidr=10.114.201.128/25 --iptables=false & timeout_iterations=0; until DOCKER_HOST="unix:///var/run/'"${target_docker_cmd}"'-host.sock" '"${target_docker_cmd}"' ps &> /dev/null; do sleep 0.2; if [ $((timeout_iterations++)) -ge 150 ]; then echo "'"${target_docker_cmd}"'-host did not come up before check timed out..."; exit 1; fi; done; echo "Starting hostapp-update"; hostapp-update -f /resinos-image.docker '"${hostapp_update_extra_args}"'' \
     || log ERROR "Update based on hostapp-update has failed..."
+
+    # Clean up after the update
+    ${DOCKER_CMD} rmi -f "${update_package}" || true
 }
 
 #######################################


### PR DESCRIPTION
On newer resinOS versions the supervisor does not clean up automatically (from 2.12.0 onwards), thus the updater needs to do that if the userspace docker engine was used.

Change-type: patch