### PR TITLE
adding support for more devices

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -763,7 +763,7 @@ progress 25 "Preparing OS update"
 
 # Check board support
 case $SLUG in
-    artik710|beaglebone*|jetson-tx1|jetson-tx2|raspberry*|skx2|ts4900)
+    artik710|beaglebone*|fincm3|jetson-tx1|jetson-tx2|odroid-c1|odroid-xu4|orangepi-plus2|raspberry*|skx2|ts4900)
         binary_type=arm
         ;;
     intel-edison|intel-nuc|iot2000|up-board|qemux86*)


### PR DESCRIPTION
Enabling the following device types

* `fincm3`
* `odroid-c1`
* `odroid-xu4` (should be only for starting version >=2.9.7)
* `orangepi-plus2`

This is a quick way to add support without refactoring, which is needed to support any hostapp-enabled system by default.

Tested the first three, the last one should be working as long as `hostapp-update` works, and that's part of the release testing.

Change-type: minor