### PR TITLE
upgrade-1.x-to-2.x: force dd to physically write stuff to disk before finishing

### DIFF
--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -519,7 +519,7 @@ case $part in
         log "Forcing remount of file systems in read-only mode..."
         echo u > /proc/sysrq-trigger
         log "Copying current root partition to the unused partiton..."
-        dd if="$(compose_device "${root_dev}" "${delimiter}" "3")" of="$(compose_device "${root_dev}" "${delimiter}" "2")" bs=4M
+        dd if="$(compose_device "${root_dev}" "${delimiter}" "3")" of="$(compose_device "${root_dev}" "${delimiter}" "2")" bs=4M conv=fsync
         log "Remounting boot partition as rw for the next step..."
         mount -o remount,rw "${boot_path}"
         log "Updating bootloader to point to first partition..."


### PR DESCRIPTION
This might help with some SD cards that are slow to write to disk. Might not, if the card's faulty or tells the system that things are written to disk, but actually not. Still should be a general improvement upon the previous state, even if `sync` was already called by the code later, just before reboot.

Change-type: patch

<img src="https://frontapp.com/assets/img/icons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_cjkr)