### PR TITLE
upgrade-2.x: add orbitty-tx2 to supported device types

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -779,7 +779,7 @@ progress 25 "Preparing OS update"
 
 # Check board support
 case $SLUG in
-    artik710|bananapi-m1-plus|beaglebone*|fincm3|imx6ul-var-dart|jetson-tx1|jetson-tx2|odroid-c1|odroid-xu4|orangepi-plus2|raspberry*|skx2|ts4900)
+    artik710|bananapi-m1-plus|beaglebone*|fincm3|imx6ul-var-dart|jetson-tx1|jetson-tx2|odroid-c1|odroid-xu4|orangepi-plus2|orbitty-tx2|raspberry*|skx2|ts4900)
         binary_type=arm
         ;;
     intel-edison|intel-nuc|iot2000|up-board|qemux86*)


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Gergely Imreh <gergely@resin.io>