### PR TITLE
upgrade-2.x: only switch docker to single download where available

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -218,7 +218,7 @@ function upgrade_supervisor() {
                     curl -s "${API_ENDPOINT}/v2/device($DEVICEID)?apikey=$APIKEY" -X PATCH -H 'Content-Type: application/json;charset=UTF-8' --data-binary "{\"supervisor_release\": \"$UPDATER_SUPERVISOR_ID\"}" > /dev/null 2>&1
                     log "Running supervisor updater..."
                     progress 90 "Running supervisor update"
-                    update-resin-supervisor
+                    update-resin-supervisor || log WARN "Supervisor couldn't be updated, continuing anyways"
                     stop_services
                     if version_gt "6.5.9" "${target_supervisor_version}" ; then
                         remove_containers
@@ -960,7 +960,10 @@ fi
 
 # Raspberry Pi 1 and certain docker versions (in resinOS <2.5.0) cannot run multilayer
 # docker pulls from Docker Hub. Workaround is limiting concurrent downloads
-if [ "$SLUG" = "raspberry-pi" ] &&
+# Apply this fix only to resinOS version >=2.0.7, though, as docker in earlier
+# versions does not have that flag, and would not run properly
+if [ "$SLUG" = "raspberry-pi" ] && \
+    version_gt "$VERSION_ID" "2.0.7" && \
     version_gt "2.5.1" "$VERSION_ID"; then
         if [ -f "/etc/systemd/system/docker.service.d/docker.conf" ]; then
             # development device have this config


### PR DESCRIPTION
For an ongoing issue with ARMv6 devices downloading multilayer images from Docker HUB, we need to switch docker to not run parallel downloads. The option used for that is only available for resinOS versions 2.0.7+ and versions below 2.5.0 are affeccted. Thus only cover those versions with the immediate fix, which is mainly needed for the supervisor update only.

For `raspberry-pi` device type (the only one affected) on resinOS versions <2.0.7, the supervisor update will not succeed in the pull step, but the device will self-recover ~15 minutes after reboot, when repulling
the supervisor by the regular scheduled supervisor updater. This inconvenience is a tradeoff, as we don't know any other workaround for this issue yet.

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@resin.io>