### PR TITLE
resinhup.conf: Remove unused mixpanelToken variable

### DIFF
--- a/app/conf/resinhup.conf
+++ b/app/conf/resinhup.conf
@@ -67,7 +67,6 @@ update_file_fingerprints: resin-boot/resin-boot.fingerprint resin-root.fingerpri
 apiEndpoint: https://api.resinstaging.io
 deltaEndpoint: https://delta.resinstaging.io
 listenPort: 48484
-mixpanelToken: cb974f32bab01ecc1171937026774b18
 pubnubPublishKey: pub-c-6cbce8db-bfd1-4fdf-a8c8-53671ae2b226
 pubnubSubscribeKey: sub-c-bbc12eba-ce4a-11e3-9782-02ee2ddab7fe
 registryEndpoint: registry.resinstaging.io
@@ -79,7 +78,6 @@ registered_at:
 apiEndpoint: https://api.resin.io
 deltaEndpoint: https://delta.resin.io
 listenPort: 48484
-mixpanelToken: 99eec53325d4f45dd0633abd719e3ff1
 pubnubPublishKey: pub-c-6cbce8db-bfd1-4fdf-a8c8-53671ae2b226
 pubnubSubscribeKey: sub-c-bbc12eba-ce4a-11e3-9782-02ee2ddab7fe
 registryEndpoint: registry.resin.io


### PR DESCRIPTION
The `resinhup.conf` configuration file contains `mixpanelToken`
variables that seem to be unused by the code.

After digging around a bit, `app/modules/updater.py` mentions
`mixpanelToken`, but in a function that converts a `resin.conf` file
that contains `MIXPANEL_TOKEN`, into `config.json`, so I believe this is
a safe deletion.

Change-type: patch